### PR TITLE
Fix title parsing

### DIFF
--- a/backend/billparser/run_through.py
+++ b/backend/billparser/run_through.py
@@ -518,7 +518,14 @@ def parse_bill(f: str, path: str, bill_obj: object, archive_obj: object):
             return []
 
         root = etree.fromstring(f)
-        title = root.xpath("//dublinCore")[0][0].text.split(":")[-1].strip()
+        try:
+            title = root.xpath("//dublinCore")[0][0].text
+            if ":" in title:
+                title = title.split(":")[-1].strip()
+        except:
+            log.error("Couldn't parse title")
+            title = "Could not find"
+
         log.info(title)
         try:
             new_bill, new_bill_version = find_or_create_bill(bill_obj, title, session)

--- a/backend/bills.json
+++ b/backend/bills.json
@@ -6,5 +6,13 @@
     {
         "title": "Senate: 116th 1st Session",
         "url": "https://www.govinfo.gov/bulkdata/BILLS/116/1/s/BILLS-116-1-s.zip"
+    },
+    {
+        "title": "House: 116th 2nd Session",
+        "url": "https://www.govinfo.gov/bulkdata/BILLS/116/2/hr/BILLS-116-2-hr.zip"
+    },
+    {
+        "title": "Senate: 116th 2nd Session",
+        "url": "https://www.govinfo.gov/bulkdata/BILLS/116/2/s/BILLS-116-2-s.zip"
     }
 ]


### PR DESCRIPTION
Sometimes there aren't any colons in the title, so we need to account for that
additionally, update to download the 2nd session zip file.