### PR TITLE
ISS-34: Pull the first effective date and display it

### DIFF
--- a/frontend/src/common/version.js
+++ b/frontend/src/common/version.js
@@ -1,1 +1,1 @@
-export const version = "0.8.3";
+export const version = "0.8.4";

--- a/frontend/src/components/billcard/index.jsx
+++ b/frontend/src/components/billcard/index.jsx
@@ -20,6 +20,11 @@ function BillCard(props) {
       </>
     );
   }
+  function getFirstEffectiveDate() {
+    const { legislation_versions = [] } = bill;
+    const dateStr = legislation_versions[0].effective_date;
+    return `${dateStr}`;
+  }
   function renderVersions() {
     const { legislation_versions = [] } = bill;
     const len = legislation_versions.length;
@@ -52,6 +57,11 @@ function BillCard(props) {
     <Card>
       <h2>{genTitle()}</h2>
       <span style={{ fontStyle: "italic" }}>{bill.title}</span>
+      <br />
+      <span className="bill-card-introduced-date">
+        <span style={{ fontWeight: "bold" }}>First Introduced:</span>{" "}
+        {getFirstEffectiveDate()}
+      </span>
       <br />
       {renderVersions()}
     </Card>


### PR DESCRIPTION
- https://github.com/Congress-Dev/congress-dev/issues/34
- Pulls the first effective_date and displays it in the bill card

This is to give a little bit more context around the bill.