### PR TITLE
Enable using XML citations in the frontend

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E501,Q000,D103,D100,D101,D102,D107,Q002,D205,D400,E203,E266,W503
+max-line-length = 88
+max-complexity = 18

--- a/backend/billparser/actions/__init__.py
+++ b/backend/billparser/actions/__init__.py
@@ -88,6 +88,12 @@ regex_holder = {
         r"The term \"(?P<term>.+?)\" means (?P<term_def>.+?).",
         r"The term (?P<term>.+?) means (?P<term_def>.+?).",
     ],
+    "DATE": [
+        r"(?:(?P<month>(?:Jan|Febr)uary|March|April|May|Ju(?:ne|ly)|August|(?:Septem|Octo|Novem|Decem)ber) (?P<day>\d\d?)\, (?P<year>\d\d\d\d))"
+    ],
+    "FINANCIAL": [
+        r"(?P<dollar>\$\s?(\d{1,3}\,?)(\d{3}\,?)*(\.\d\d)?)"
+    ]
 }
 
 SuchCodeRegex = re.compile(r"(Section|paragraph) (?P<section>\d*)\(", re.IGNORECASE)

--- a/backend/billparser/actions/strike.py
+++ b/backend/billparser/actions/strike.py
@@ -3,6 +3,7 @@ from billparser.db.models import USCContentDiff, USCSection, USCContent
 from billparser.logger import log
 import re
 from billparser.actions import ActionObject
+from billparser.utils.citation import remove_citations
 
 
 def strike_section(action_obj: ActionObject, session: "Session") -> None:
@@ -67,6 +68,7 @@ def strike_emulation(to_strike: str, to_replace: str, target: str) -> str:
     start_boi = r"(\s|\b)"
     if re.match(r"[^\w]", to_strike):
         start_boi = ""
+    target = remove_citations(target)
     if "$" not in to_strike:
         return re.sub(
             r"{}({})(?:\s|\b)".format(start_boi, re.escape(to_strike)),

--- a/backend/billparser/db/models.py
+++ b/backend/billparser/db/models.py
@@ -550,6 +550,9 @@ class LegislationCommitteeAssociation(Base):
     referred_date = Column(DateTime)
     discharge_date = Column(DateTime)
     
+    legislation_id = Column(
+        Integer, ForeignKey("legislation.legislation_id"), index=True
+    )
     legsilation_id = Column(
         Integer, ForeignKey("legislation.legislation_id"), index=True
     )

--- a/backend/billparser/importers/releases.py
+++ b/backend/billparser/importers/releases.py
@@ -26,6 +26,7 @@ if __name__ == "__main__":
     for rp in release_points:
         print("=" * 5)
         print(rp.get("short_title"))
+        rp["short_title"] = datetime.now().strftime("%D %T")
         existing_rp = (
             session.query(USCRelease)
             .filter(

--- a/backend/billparser/importers/releases.py
+++ b/backend/billparser/importers/releases.py
@@ -64,6 +64,6 @@ if __name__ == "__main__":
                     rp.get("title"),
                     release_point.to_dict(),
                 )
-                for file in files
+                for file in files  # if "09" in file
             )
 

--- a/backend/billparser/importers/statuses.py
+++ b/backend/billparser/importers/statuses.py
@@ -1,0 +1,21 @@
+import os
+from billparser.status_parser import parse_archive
+
+url_format = "https://www.govinfo.gov/bulkdata/BILLSTATUS/{congress}/{prefix}/BILLSTATUS-{congress}-{prefix}.zip"
+
+congresses = [116]
+
+def download_path(url: str):
+    os.makedirs("statuses", exist_ok=True)
+    output_name = url.split("/")[-1]
+    if os.path.exists(f"statuses/{output_name}"):
+        return output_name
+    os.system(f"wget {url} --output-document statuses/{output_name}")
+    return output_name
+
+if __name__ == "__main__":
+    for congress in congresses:
+        for prefix in ["s", "hr"]:
+            url = url_format.format(**{"congress": congress, "prefix": prefix})
+            output_name = download_path(url)
+            parse_archive(f"statuses/{output_name}")

--- a/backend/billparser/status_parser.py
+++ b/backend/billparser/status_parser.py
@@ -1,0 +1,78 @@
+from zipfile import ZipFile
+from typing import List
+from lxml import etree
+from lxml.etree import Element
+from billparser.db.models import (
+    LegislationCommittee,
+    Legislation,
+    LegislationCommitteeAssociation,
+    LegislationChamber,
+)
+from billparser.db.handler import Session
+
+
+def handle_committees(committee_elements: List[Element]):
+    # TODO: Create Committee records using https://github.com/unitedstates/congress-legislators/tree/master/scripts
+
+    session = Session()
+    for committee in committee_elements:
+        obj = {e.tag: e.text for e in committee}
+        existing_obj: LegislationCommittee = (
+            session.query(LegislationCommittee)
+            .filter(
+                LegislationCommittee.system_code == obj["systemCode"],
+                LegislationCommittee.chamber == obj["chamber"],
+            )
+            .first()
+        )
+        if existing_obj is None:
+            new_obj = LegislationCommittee(
+                system_code=obj["systemCode"],
+                chamber=LegislationChamber(obj["chamber"]),
+                name=obj["name"],
+                committee_type=obj["type"],
+            )
+            session.add(new_obj)
+            session.commit()
+            committee_id = new_obj.legislation_committee_id
+        else:
+            committee_id = existing_obj.legislation_committee_id
+
+        for subcommitte in committee.xpath(".//subcommittees/item"):
+            s_obj = {e.tag: e.text for e in subcommitte}
+            existing_obj = (
+                session.query(LegislationCommittee)
+                .filter(
+                    LegislationCommittee.system_code == s_obj["systemCode"],
+                    LegislationCommittee.chamber == obj["chamber"],
+                )
+                .first()
+            )
+            if existing_obj is None:
+                new_obj = LegislationCommittee(
+                    system_code=s_obj["systemCode"],
+                    chamber=LegislationChamber(obj["chamber"]),
+                    name=s_obj["name"],
+                    subcommittee=committee_id,
+                )
+                session.add(new_obj)
+                session.commit()
+
+    pass
+
+
+def parse_status(input_str: str):
+    try:
+        root = etree.fromstring(input_str)
+        bill_element = root.xpath("//bill")[0]
+        committees = root.xpath("//billCommittees/item")
+        handle_committees(committees)
+    except Exception as e:
+        print(e)
+
+
+def parse_archive(f_path: str):
+    archive = ZipFile(f_path)
+    for file in archive.namelist():
+        r = archive.open(file, "r").read()
+        parse_status(r)

--- a/backend/billparser/status_parser.py
+++ b/backend/billparser/status_parser.py
@@ -2,6 +2,9 @@ from zipfile import ZipFile
 from typing import List
 from lxml import etree
 from lxml.etree import Element
+
+from dateutil.parser import parse
+
 from billparser.db.models import (
     LegislationCommittee,
     Legislation,
@@ -11,7 +14,31 @@ from billparser.db.models import (
 from billparser.db.handler import Session
 
 
-def handle_committees(committee_elements: List[Element]):
+def _ensure_committee_link(committee_id, legislation_id, referred_date, discharge_date):
+    session = Session()
+    existing_obj: LegislationCommitteeAssociation = (
+        session.query(LegislationCommitteeAssociation)
+        .filter(
+            LegislationCommitteeAssociation.legislation_committee_id == committee_id,
+            LegislationCommitteeAssociation.legislation_id == legislation_id,
+        )
+        .first()
+    )
+    if existing_obj is None:
+        new_obj = LegislationCommitteeAssociation(
+            legislation_committee_id=committee_id,
+            legislation_id=legislation_id,
+            referred_date=parse(referred_date),
+            discharge_date=parse(discharge_date),
+            congress_id=None,
+        )
+        session.add(new_obj)
+    else:
+        existing_obj.discharge_date = parse(discharge_date)
+    session.commit()
+
+
+def handle_committees(committee_elements: List[Element], bill_object: Legislation):
     # TODO: Create Committee records using https://github.com/unitedstates/congress-legislators/tree/master/scripts
 
     session = Session()
@@ -37,6 +64,21 @@ def handle_committees(committee_elements: List[Element]):
             committee_id = new_obj.legislation_committee_id
         else:
             committee_id = existing_obj.legislation_committee_id
+        committee_activities = committee.xpath(".//activities/item")
+        com_referred_date = None
+        com_discharge_date = None
+        for activity in committee_activities:
+            a_obj = {e.tag: e.text for e in activity}
+            if a_obj["name"].lower() == "referred to":
+                com_referred_date = a_obj["date"]
+            elif a_obj["name"].lower() == "discharged from":
+                com_discharge_date = a_obj["date"]
+        _ensure_committee_link(
+            committee_id,
+            bill_object.legislation_id,
+            com_referred_date,
+            com_discharge_date,
+        )
 
         for subcommitte in committee.xpath(".//subcommittees/item"):
             s_obj = {e.tag: e.text for e in subcommitte}
@@ -57,7 +99,24 @@ def handle_committees(committee_elements: List[Element]):
                 )
                 session.add(new_obj)
                 session.commit()
-
+                subcommitte_id = new_obj.legislation_committee_id
+            else:
+                subcommitte_id = existing_obj.legislation_committee_id
+            subcommittee_activities = subcommitte.xpath(".//activities/item")
+            scom_referred_date = None
+            scom_discharge_date = None
+            for activity in subcommittee_activities:
+                a_obj = {e.tag: e.text for e in activity}
+                if a_obj["name"].lower() == "referred to":
+                    scom_referred_date = a_obj["date"]
+                elif a_obj["name"].lower() == "discharged from":
+                    scom_discharge_date = a_obj["date"]
+            _ensure_committee_link(
+                subcommitte_id,
+                bill_object.legislation_id,
+                scom_referred_date,
+                scom_discharge_date,
+            )
     pass
 
 
@@ -66,7 +125,25 @@ def parse_status(input_str: str):
         root = etree.fromstring(input_str)
         bill_element = root.xpath("//bill")[0]
         committees = root.xpath("//billCommittees/item")
-        handle_committees(committees)
+        bill_info = {
+            e.tag: e.text
+            for e in bill_element
+            if e.tag in ["billNumber", "originChamber", "billType", "congress"]
+        }
+        session = Session()
+        # TODO: Filter on Legislation type, congress
+        matching_bill: Legislation = (
+            session.query(Legislation)
+            .filter(
+                Legislation.chamber == LegislationChamber(bill_info["originChamber"]),
+                Legislation.number == bill_info["billNumber"],
+            )
+            .first()
+        )
+        if matching_bill is None:
+            print("Did not find bill")
+            matching_bill = Legislation(legislation_id=1)
+        handle_committees(committees, matching_bill)
     except Exception as e:
         print(e)
 

--- a/backend/billparser/utils/citation.py
+++ b/backend/billparser/utils/citation.py
@@ -1,0 +1,82 @@
+import re
+
+
+def resolve_citations(text: str, title_num: str) -> str:
+    """
+        Puts xml tags around all citations
+    """
+    title_cites = [
+        r"\W(sections? (?P<inner>.*?) of (?P<title>(?:this )?title(?:\d\d?)?))\W",
+        r"\W(section (?P<section>\d*)(?P<subsection>\(.*?\))? of (?P<title>this title))\W",
+        r"\W(section (?P<section>\d*)(?P<subsection>\(.*?\))? of title (?P<title>\d\d?))\W",
+        r"\W(section (?P<section>\d*))\W",
+    ]
+
+    def spit_out_xml(t, s, text):
+        return f'<usccite src="/usc/{t}/{s}">{text}</usccite>'
+
+    subsect_reg = r"(?P<section>\d+)?(?P<subsections>(?:\(.*?\))*)?"
+    for regex_str in title_cites:
+        result = ""
+        matches = re.search(regex_str, text, re.MULTILINE + re.IGNORECASE)
+        if matches is not None:
+            group_matches = matches.groupdict()
+            last_ind = 0
+            title_num_m = group_matches.get("title", "this title")
+            if title_num_m == "this title":
+                title_num_m = title_num
+            if "section" in group_matches:
+                sec_num = group_matches.get("section")
+
+                end_ind = 0
+                if "title" in group_matches:
+                    end_ind = matches.end("title")
+                else:
+                    end_ind = matches.end("section")
+                p_str = spit_out_xml(
+                    title_num_m,
+                    sec_num,
+                    f"section {text[matches.start('section'):end_ind]}",
+                )
+                # TODO: Is recursion the best option here?
+                return (
+                    resolve_citations(
+                        text[last_ind : matches.start("section") - len("section ")],
+                        title_num_m,
+                    )
+                    + p_str
+                    + resolve_citations(text[end_ind:], title_num_m)
+                )
+            elif "inner" in group_matches:
+                inner_ind = matches.start("inner")
+                end_ind = matches.end("inner")
+                inner_str = group_matches.get("inner")
+                inner_matches = re.finditer(subsect_reg, inner_str)
+                current_section = None
+                p_str = ""
+                last_inner_ind = 0
+                for sub_match in inner_matches:
+                    if sub_match.group(0) != "":
+                        g_dict = sub_match.groupdict()
+                        current_section = g_dict.get("section") or current_section
+                        subsect = g_dict.get("subsections")
+                        p_str += inner_str[
+                            last_inner_ind : sub_match.start()
+                        ] + spit_out_xml(
+                            title_num_m,
+                            current_section,
+                            inner_str[sub_match.start() : sub_match.end()],
+                        )
+                        last_inner_ind = sub_match.end()
+                return (
+                    resolve_citations(
+                        text[last_ind : matches.start("inner")], title_num_m
+                    )
+                    + p_str
+                    + resolve_citations(text[end_ind:], title_num_m)
+                )
+    return text
+
+
+def remove_citations(text: str) -> str:
+    return re.sub(r"\<usccite src.*?\"\>", "", text, count=200).replace("</usccite>", "")

--- a/backend/bills.json
+++ b/backend/bills.json
@@ -1,22 +1,12 @@
 [
   {
-    "title": "House: 116th 1st Session",
-    "congress": 116,
-    "url": "https://www.govinfo.gov/bulkdata/BILLS/116/1/hr/BILLS-116-1-hr.zip"
+    "title": "House: 117th 1st Session",
+    "congress": 117,
+    "url": "https://www.govinfo.gov/bulkdata/BILLS/117/1/hr/BILLS-117-1-hr.zip"
   },
   {
-    "title": "Senate: 116th 1st Session",
-    "congress": 116,
-    "url": "https://www.govinfo.gov/bulkdata/BILLS/116/1/s/BILLS-116-1-s.zip"
-  },
-  {
-    "title": "House: 116th 2nd Session",
-    "congress": 116,
-    "url": "https://www.govinfo.gov/bulkdata/BILLS/116/2/hr/BILLS-116-2-hr.zip"
-  },
-  {
-    "title": "Senate: 116th 2nd Session",
-    "congress": 116,
-    "url": "https://www.govinfo.gov/bulkdata/BILLS/116/2/s/BILLS-116-2-s.zip"
+    "title": "Senate: 117th 1st Session",
+    "congress": 117,
+    "url": "https://www.govinfo.gov/bulkdata/BILLS/117/1/s/BILLS-117-1-s.zip"
   }
 ]

--- a/backend/rp.json
+++ b/backend/rp.json
@@ -1,8 +1,9 @@
 [
     {
-        "date": "01/14/2019",
-        "short_title": "Public Law 115-442",
-        "long_title": "Affecting titles 2, 5, 7, 12, 15, 16, 18, 19, 20, 21, 22, 25, 31, 33, 34, 39, 40, 42, 43, 47",
-        "url": "https://uscode.house.gov/download/releasepoints/us/pl/115/442/xml_uscAll@115-442.zip"
+        "date": "12/23/2020",
+        "short_title": "Public Law 116-259",
+        "long_title": "Affecting titles 6, 10, 15, 20, 28, 31, 33, 36, 37, 38, 40, and 46",
+        "url": "https://uscode.house.gov/download/releasepoints/us/pl/116/259/xml_uscAll@116-259.zip"
     }
+
 ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^16.12.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.3.1",
-    "react-spinners": "^0.8.0"
+    "react-spinners": "^0.8.0",
+    "xmldoc": "^1.1.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -36,3 +36,7 @@
     transform: rotate(360deg);
   }
 }
+
+a {
+  text-decoration: underline;
+}

--- a/frontend/src/common/api.js
+++ b/frontend/src/common/api.js
@@ -37,7 +37,7 @@ export const getBillVersionText = (congress, chamber, billNumber, billVersion) =
         const sorted = lodash.sortBy(
           flatJson.content,
           ({ legislation_content_id, order_number }) =>
-            `${legislation_content_id}.${order_number.toString().padStart(3, "0")}`
+            `${legislation_content_id.toString().padStart(10, "0")}.${order_number.toString().padStart(3, "0")}`
         );
         if (sorted.length === 0) {
           return {};

--- a/frontend/src/components/billcard/index.jsx
+++ b/frontend/src/components/billcard/index.jsx
@@ -55,7 +55,7 @@ function BillCard(props) {
   }
   return (
     <Card>
-      <h2>{genTitle()}</h2>
+      <h2 style={{marginTop: "0px"}}>{genTitle()}</h2>
       <span style={{ fontStyle: "italic" }}>{bill.title}</span>
       <br />
       <span className="bill-card-introduced-date">

--- a/frontend/src/components/billdisplay/index.jsx
+++ b/frontend/src/components/billdisplay/index.jsx
@@ -20,15 +20,14 @@ function BillDisplay(props) {
   // TODO: Add permalink feature
   // TODO: Add highlight feature to permalink in the url ?link=a/1/ii&highlight=a/1/ii,a/1/v
   const history = useHistory();
-
-  const [textTree, setTextTree] = useState({});
+  const textTree = props.textTree;
+  // const [textTree, setTextTree] = useState({});
   const [activeHash, setActiveHash] = useState(
     (history.location.hash || "#").slice(1) || ""
   );
 
   const [renderedTarget, setRenderedTarget] = useState(false);
 
-  console.log(activeHash);
   useEffect(() => {
     // If we render the hash target, go ahead and zip it into view
     if (renderedTarget) {
@@ -37,9 +36,13 @@ function BillDisplay(props) {
   }, [renderedTarget]);
 
   useEffect(() => {
+    setActiveHash((history.location.hash || "#").slice(1) || "");
+  }, [history.location.hash])
+
+  useEffect(() => {
     const { congress, chamber, billNumber, billVersion } = props;
-    setTextTree({ loading: true });
-    getBillVersionText(congress, chamber, billNumber, billVersion).then(setTextTree);
+    // setTextTree({ loading: true });
+    // getBillVersionText(congress, chamber, billNumber, billVersion).then(setTextTree);
   }, [props.billVersion]);
 
   function goUpParentChain(element) {
@@ -179,10 +182,10 @@ function BillDisplay(props) {
           ) => {
             let actionStr = generateActionStr(action);
             content_str = generateActionHighlighting(content_str, action);
-            const itemHash = (lc_ident || "").toLowerCase();
+            const itemHash = (`${lc_ident || legislation_content_id}`).toLowerCase();
             const outerClass = `bill-content-${content_type} bill-content-section ${
               activeHash !== "" && activeHash === itemHash ? "usc-content-hash" : ""
-            }`;
+              }`;
             if (!renderedTarget && itemHash && activeHash && itemHash === activeHash) {
               setRenderedTarget(true);
             }
@@ -241,10 +244,12 @@ function BillDisplay(props) {
       </>
     );
   }
-  if (textTree.loading) {
+  if (textTree.loading || textTree.content_type !== "legis-body") {
     return <SyncLoader loading={true} />;
   }
-  return <>{renderRecursive(textTree)}</>;
+
+  // TODO: Convert this to recursive components to speed up rerenders
+  return <>{renderRecursive(props.textTree)}</>;
 }
 
 export default BillDisplay;

--- a/frontend/src/components/billviewanchorlistcomp/index.jsx
+++ b/frontend/src/components/billviewanchorlistcomp/index.jsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from "react";
+import lodash from "lodash";
+import { md5 } from "common/other";
+import { useHistory } from "react-router-dom";
+function BillViewAnchorList(props) {
+    const history = useHistory();
+    const { anchors } = props;
+    return <><p>Grey and crossed out means we detected it, but are unable to offer a jump to view of it at this moment</p>{
+        lodash.map(anchors, (arr, ind) => {
+            if (arr[1] !== undefined) {
+                return <p className="anchor-list-link" key={ind} onClick={() => {
+                    history.replace({ hash: arr[1] });
+                    document.getElementById(arr[1]).scrollIntoView();
+                }}>{arr[0]}</p>
+            } else {
+                return <p className="anchor-list-bad" key={ind} >{arr[0]}</p>
+            }
+        })
+    }</>
+}
+
+
+export default BillViewAnchorList;

--- a/frontend/src/components/billviewsidebar/index.jsx
+++ b/frontend/src/components/billviewsidebar/index.jsx
@@ -1,3 +1,0 @@
-// Will handle creating a sidebar showing what parts of the USCode have differences
-// TODO: Searching
-// TODO: Highlight different colors based on adding/subtracting text amounts

--- a/frontend/src/pages/billviewer/index.jsx
+++ b/frontend/src/pages/billviewer/index.jsx
@@ -78,13 +78,12 @@ function BillViewer(props) {
     if (billVers !== undefined) {
       // Make sure to push the search and hash onto the url
       props.history.push(
-        `/bill/${congress}/${chamber}/${billNumber}/${
-        billVers || billVersion
+        `/bill/${congress}/${chamber}/${billNumber}/${billVers || billVersion
         }${diffStr}` +
         props.location.search +
         props.location.hash
       );
-      getBillVersionText(congress, chamber, billNumber, billVersion).then(setTextTree);
+      getBillVersionText(congress, chamber, billNumber, billVers).then(setTextTree);
     }
   }, [billVers]);
   useEffect(() => {
@@ -118,7 +117,7 @@ function BillViewer(props) {
       _dates = [..._dates, ...dates];
       _dollars = [..._dollars, ...dollars];
     });
-    const itemHash = `${ _textTree.lc_ident || _textTree.legislation_content_id}`.toLowerCase();
+    const itemHash = `${_textTree.lc_ident || _textTree.legislation_content_id}`.toLowerCase();
     let m;
     while ((m = dateRegex.exec(_textTree.content_str)) !== null) {
       // This is necessary to avoid infinite loops with zero-width matches

--- a/frontend/src/pages/uscodeviewer/index.jsx
+++ b/frontend/src/pages/uscodeviewer/index.jsx
@@ -9,9 +9,10 @@ function USCodeViewer(props) {
   const [section, setSection] = useState(null);
   console.log(props.match);
   const { uscReleaseId, uscTitle, uscSection } = props.match.params;
+  console.log(window.innerHeight);
   return (
     <>
-      <div className="sidebar">
+      <div className="sidebar" style={{height: `${window.innerHeight - 70}px`, overflow: 'auto'}}>
         <USCSidebar release={uscReleaseId} title={(uscTitle || "").replace("#", "")} section={uscSection} />
       </div>
       <div className="content">

--- a/frontend/src/styles/bill-view.scss
+++ b/frontend/src/styles/bill-view.scss
@@ -1,6 +1,7 @@
 .bill-content-section {
   margin-left: 20px;
   margin-bottom: 0px;
+  line-height: 20px;
 }
 
 .bill-content-continue {
@@ -35,4 +36,13 @@
   border-style: solid;
   border-color: gray;
   background-color: lightgray;
+}
+
+.anchor-list-bad {
+  text-decoration: line-through;
+  color: lightgray;
+}
+
+.anchor-list-link {
+  cursor: pointer;
 }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9472,7 +9472,7 @@ sass-loader@8.0.2:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@^1.2.1, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -11214,6 +11214,13 @@ xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmldoc@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-1.1.2.tgz#6666e029fe25470d599cd30e23ff0d1ed50466d7"
+  integrity sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==
+  dependencies:
+    sax "^1.2.1"
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
- We start attempting to find internal citations to other sections of the USC, and highlight them using XML
  - The frontend looks for this and creates links to the predicted section
  - The legislation parser has to remove these citations and put them back while parsing changes

- Add the beginning of date and financial amount highlighting for legistation
  - Shows up as a tabbed sidebar thing when viewing legislation
  - Offers a link to the text within the bill for easy access