### PR TITLE
Feature: Add vector DB backed USCode search

### DIFF
--- a/backend/congress_fastapi/app.py
+++ b/backend/congress_fastapi/app.py
@@ -11,6 +11,7 @@ from congress_fastapi.routes.legislation_version import (
 from congress_fastapi.routes.search import router as search_router
 from congress_fastapi.routes.user import router as user_router
 from congress_fastapi.routes.stats import router as stats_router
+from congress_fastapi.routes.uscode import router as uscode_router
 from congress_fastapi.utils.limiter import limiter
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -52,4 +53,5 @@ app.include_router(legislation_version_router)
 app.include_router(search_router)
 app.include_router(user_router)
 app.include_router(stats_router)
+app.include_router(uscode_router)
 print("Loaded")

--- a/backend/congress_fastapi/handlers/uscode.py
+++ b/backend/congress_fastapi/handlers/uscode.py
@@ -1,0 +1,97 @@
+import os
+from typing import List, Optional
+import chromadb
+from chromadb.api.models.AsyncCollection import AsyncCollection
+from chromadb.api.types import IncludeEnum
+from chromadb.config import DEFAULT_TENANT, DEFAULT_DATABASE, Settings
+from sqlalchemy import select, or_
+
+from congress_fastapi.db.postgres import get_database
+from billparser.db.models import (
+    USCContent,
+    USCChapter,
+)
+
+chroma_host = (
+    os.environ.get("LLM_HOST", "10.0.0.120").split("http://")[-1].split(":")[0]
+)
+
+
+async def get_usc_content_by_citation(citation: str) -> Optional[USCContent]:
+    database = await get_database()
+    query = select(USCContent).where(USCContent.usc_ident == citation)
+    result = await database.fetch_one(query)
+    return result
+
+
+async def get_usc_content_by_citations(citations: List[str]) -> List[USCContent]:
+    database = await get_database()
+    query = select(
+        USCContent,
+    ).where(
+        or_(*[USCContent.usc_ident == cite for cite in citations]),
+        USCContent.version_id == 74573,
+    )
+    results = await database.fetch_all(query)
+    return results
+
+
+async def get_usc_chapter_by_short_title(short_title: str) -> Optional[USCChapter]:
+    database = await get_database()
+    query = select(USCChapter).where(USCChapter.short_title == short_title)
+    result = await database.fetch_one(query)
+    return result
+
+
+async def get_usc_chapter_by_short_titles(short_titles: List[str]) -> List[USCChapter]:
+    r = []
+    for title in short_titles:
+        if len(title) < 2:
+            title = "0" + title
+        r.append(title)
+    short_titles = r
+    database = await get_database()
+    query = select(
+        USCChapter,
+    ).where(
+        or_(*[USCChapter.short_title == title for title in short_titles]),
+        USCChapter.version_id == 74573,
+    )
+    results = await database.fetch_all(query)
+    return results
+
+
+async def search_chroma(query: str, num: int) -> List[dict]:
+    CHROMADB = await chromadb.AsyncHttpClient(
+        host=chroma_host,
+        port=8000,
+        ssl=False,
+        headers=None,
+        settings=Settings(),
+        tenant="congress-dev",
+        database="usc-chat",
+    )
+    collection: AsyncCollection = await CHROMADB.get_collection("uscode")
+    response = await collection.query(
+        query_texts=[query], n_results=num, include=[IncludeEnum.metadatas]
+    )
+    usc_contents = await get_usc_content_by_citations(response["ids"][0])
+    short_titles = [x.usc_ident.split("/")[3].split("t")[-1] for x in usc_contents]
+    usc_chapters = await get_usc_chapter_by_short_titles(short_titles)
+    chapters_by_id = {f"t{x.short_title.strip()}": x for x in usc_chapters}
+
+    contents_by_id = {x.usc_ident: x for x in usc_contents}
+
+    results_by_id = {}
+    for ident, content in contents_by_id.items():
+        result = {}
+        short_title = ident.split("/")[3]
+        chapter = chapters_by_id.get(short_title.lower().strip())
+        if chapter:
+            result["title"] = chapter.long_title.capitalize().strip()
+        else:
+            result["title"] = short_title.capitalize()
+        result["section_display"] = content.heading.strip()
+        result["usc_link"] = f"{short_title[1:]}/{content.number}"
+        results_by_id[ident] = result
+    return [results_by_id[ident] for ident in response["ids"][0]]

--- a/backend/congress_fastapi/handlers/user.py
+++ b/backend/congress_fastapi/handlers/user.py
@@ -488,7 +488,7 @@ async def insert_llm_query_result(
     database = await get_database()
     query = insert(UserLLMQuery).values(
         legislation_version_id=legislation_version_id,
-        user_id: user,
+        user_id= user,
         query=query,
         response=response,
         safe=False,

--- a/backend/congress_fastapi/handlers/user.py
+++ b/backend/congress_fastapi/handlers/user.py
@@ -483,11 +483,12 @@ async def get_llm_query_result(
 
 
 async def insert_llm_query_result(
-    legislation_version_id: int, query: str, response: str
+    legislation_version_id: int, query: str, response: str, user: str
 ) -> None:
     database = await get_database()
     query = insert(UserLLMQuery).values(
         legislation_version_id=legislation_version_id,
+        user_id: user,
         query=query,
         response=response,
         safe=False,

--- a/backend/congress_fastapi/models/uscode.py
+++ b/backend/congress_fastapi/models/uscode.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from pydantic import validator
+
+
+class USCodeSearchRequest(BaseModel):
+    query: str
+    results: int
+
+    @validator("results")
+    def results_must_be_valid(cls, v):
+        if not 1 <= v <= 20:
+            raise ValueError("Results must be a positive integer not greater than 20")
+        return v
+
+class USCodeSearchResponse(BaseModel):
+    usc_link: str
+    section_display: str
+    title: str

--- a/backend/congress_fastapi/routes/legislation_version.py
+++ b/backend/congress_fastapi/routes/legislation_version.py
@@ -176,7 +176,8 @@ async def get_legislation_version_summary(
     obj = await get_legislation_version_summary_by_version(legislation_version_id)
     if obj is None:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Legislation version session not found"
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Legislation version session not found",
         )
     return obj
 
@@ -230,7 +231,7 @@ async def post_legislation_version_llm(
         query_request.query, content, metadata_context
     )
     await insert_llm_query_result(
-        legislation_version_id, query_request.query, response.response
+        legislation_version_id, query_request.query, response.response, user.user_id
     )
 
     return response

--- a/backend/congress_fastapi/routes/uscode.py
+++ b/backend/congress_fastapi/routes/uscode.py
@@ -1,0 +1,18 @@
+from typing import Any, Dict, List
+from billparser.db.models import LegislationVersionEnum
+
+from congress_fastapi.handlers.uscode import search_chroma
+from congress_fastapi.models.uscode import USCodeSearchRequest, USCodeSearchResponse
+from fastapi import APIRouter, HTTPException, Query, status
+
+from congress_fastapi.handlers.legislation_metadata import (
+    get_legislation_metadata_by_legislation_id,
+)
+from congress_fastapi.models.errors import Error
+from congress_fastapi.models.legislation import LegislationMetadata
+
+router = APIRouter(tags=["USCode"])
+
+@router.post("/uscode/search")
+async def post_uscode_search(body: USCodeSearchRequest) -> List[USCodeSearchResponse]:
+    return await search_chroma(body.query, body.results)

--- a/frontend/src/common/api.js
+++ b/frontend/src/common/api.js
@@ -475,3 +475,16 @@ export const talkToBill = (legislationVersionId, query) => {
     }).then(handleStatus);
     // .catch(toastError);
 };
+
+export const getUSCodeSearch = (query) => {
+    return fetch(`${endPv2}/uscode/search`, {
+        method: "POST",
+        body: JSON.stringify({ query, results: 10 }),
+        headers: {
+            "Content-Type": "application/json",
+        },
+        credentials: "include",
+    })
+        .then(handleStatus)
+        .catch(toastError);
+};

--- a/frontend/src/components/usc-view/index.jsx
+++ b/frontend/src/components/usc-view/index.jsx
@@ -39,44 +39,52 @@ function findCommonSuffix(str1, str2) {
     return i;
 }
 
-function findDiffStrings(str1, str2, maxSuffixLen = 0){
-  const words1 = str1.split(' ');
-  const words2 = str2.split(' ');
-  
-  const minLength = Math.min(words1.length, words2.length);
-  const differences = [];
-  let start = null;
-  let end = 0;
-  for (let i = 0; i < minLength; i++) {
+function findDiffStrings(str1, str2, maxSuffixLen = 0) {
+    const words1 = str1.split(" ");
+    const words2 = str2.split(" ");
 
-      if (words1[i] !== words2[i]) {
-          if (start === null) {
-              start = i;
-          }
-          end = i;
-      } else {
-          if (start !== null) {
-              differences.push([start, end]);
-              start = null;
-          }
-      }
-  }
-  
-  if (start !== null) {
-      differences.push([start, end]);
-  }
-  
-  // Ensure there are at least 3 words between separate differences
-  const filteredDifferences = [];
-  for (let i = 0; i < differences.length; i++) {
-      if (i === 0 || differences[i][0] - differences[i - 1][1] > 3) {
-          filteredDifferences.push(differences[i]);
-      }
-  }
-  
-  return filteredDifferences;
+    const minLength = Math.min(words1.length, words2.length);
+    const differences = [];
+    let start = null;
+    let end = 0;
+    for (let i = 0; i < minLength; i++) {
+        if (words1[i] !== words2[i]) {
+            if (start === null) {
+                start = i;
+            }
+            end = i;
+        } else {
+            if (start !== null) {
+                differences.push([start, end]);
+                start = null;
+            }
+        }
+    }
+
+    if (start !== null) {
+        differences.push([start, end]);
+    }
+
+    // Ensure there are at least 3 words between separate differences
+    const filteredDifferences = [];
+    for (let i = 0; i < differences.length; i++) {
+        if (i === 0 || differences[i][0] - differences[i - 1][1] > 3) {
+            filteredDifferences.push(differences[i]);
+        }
+    }
+
+    return filteredDifferences;
 }
-function USCView({ release, title, section, diffs = {}, interactive = true }) {
+function USCView({
+    release,
+    title,
+    section,
+    diffs = {},
+    interactive = true,
+    depth = 0,
+    lines = 0,
+}) {
+  let lineCount = 0;
     const history = useHistory();
 
     const [contentTree, setContentTree] = useState({});
@@ -169,8 +177,7 @@ function USCView({ release, title, section, diffs = {}, interactive = true }) {
                     itemDiff[key] !== undefined &&
                     itemDiff[key] !== item[key]
                 ) {
-
-                  const diffStart = findCommonPrefix(
+                    const diffStart = findCommonPrefix(
                         item[key],
                         itemDiff[key],
                     );
@@ -243,7 +250,10 @@ function USCView({ release, title, section, diffs = {}, interactive = true }) {
         }
     }
 
-    function renderRecursive(node) {
+    function renderRecursive(node, rDepth = 0) {
+        if (depth && rDepth > depth) {
+            return null;
+        }
         const newChildren = lodash
             .chain(node.children || [])
             .map(computeDiff)
@@ -252,6 +262,10 @@ function USCView({ release, title, section, diffs = {}, interactive = true }) {
         return (
             <>
                 {lodash.map(newChildren, (item, ind) => {
+                  lineCount++;
+                  if (lines && lineCount > lines) {
+                    return null;
+                  }
                     const {
                         usc_content_id,
                         usc_ident,
@@ -307,7 +321,7 @@ function USCView({ release, title, section, diffs = {}, interactive = true }) {
                                     {content_str}
                                 </span>
                             </span>
-                            {renderRecursive({ children })}
+                            {renderRecursive({ children}, rDepth + 1)}
                         </div>
                     );
                 })}

--- a/frontend/src/pages/bill-viewer/index.jsx
+++ b/frontend/src/pages/bill-viewer/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, useContext } from "react";
 import lodash from "lodash";
 import { useHistory } from "react-router-dom";
 import {
@@ -7,10 +7,9 @@ import {
     SectionCard,
     Popover,
     Button,
-    PopperPlacements
 } from "@blueprintjs/core";
 
-import { BillContext } from "context";
+import { BillContext, LoginContext } from "context";
 
 import { chamberLookup, versionToFull } from "common/lookups";
 import {
@@ -40,6 +39,9 @@ function BillViewer(props) {
 
     const elementRef = useRef();
     const history = useHistory();
+
+    // DEBUG: Just to make it easier to debug bills
+    const { user } = useContext(LoginContext);
 
     // TODO: Add sidebar for viewing the differences that a bill will generate
     // TODO: Option for comparing two versions of the same bill and highlighting differences
@@ -231,7 +233,12 @@ function BillViewer(props) {
             <Section
                 className="page"
                 title={bill.title}
-                subtitle={`${chamberLookup[bill.chamber]} ${bill.number}`}
+                subtitle={
+                    (user && user.userId === "mustyoshi@gmail.com"
+                        ? `${billVersId} - `
+                        : null) +
+                    `${chamberLookup[bill.chamber]} ${bill.number}`
+                }
             >
                 <SectionCard>
                     <div className="sidebar">

--- a/frontend/src/pages/uscode-revision-list/index.jsx
+++ b/frontend/src/pages/uscode-revision-list/index.jsx
@@ -28,8 +28,8 @@ function USCodeRevisionList() {
                 key={`search-result-${index}`}
                 className="search-result"
             >
-                <h3>{result.title}</h3>
-                <h4>{result.sectionHeader}</h4>
+                <h3>Ch. {result.usc_link.split("/")[0]} - {result.title}</h3>
+                <h4>S. {result.usc_link.split("/")[1]} - {result.section_display}</h4>
             </SectionCard>
         ));
     };

--- a/frontend/src/pages/uscode-revision-list/index.jsx
+++ b/frontend/src/pages/uscode-revision-list/index.jsx
@@ -1,51 +1,99 @@
-// Hold the different versions of the USCode we can look at
 import React, { useEffect, useState } from "react";
 import lodash from "lodash";
-import { Section, SectionCard } from "@blueprintjs/core";
+import { Section, SectionCard, InputGroup, Button } from "@blueprintjs/core";
 
 import { USCRevisionBox } from "components";
-import { getUSCRevisions } from "common/api";
+import { getUSCRevisions, getUSCodeSearch } from "common/api";
 
 function USCodeRevisionList() {
     const [releases, setReleases] = useState([]);
+    const [query, setQuery] = useState("");
+    const [searchResults, setSearchResults] = useState([]);
 
     useEffect(() => {
         getUSCRevisions().then(setReleases);
     }, []);
 
-    return (
-        <Section
-            className="page"
-            title="United States Code"
-            subtitle="The Foundation of U.S. Law"
-        >
-            <SectionCard>
-                {lodash.map(
-                    releases,
-                    (
-                        {
-                            usc_release_id,
-                            effective_date,
-                            long_title,
-                            short_title,
-                            url,
-                        },
-                        ind,
-                    ) => (
-                        <USCRevisionBox
-                            key={`usc-rev-box-${ind}`}
-                            usc_release_id={usc_release_id}
-                            effective_date={effective_date}
-                            long_title={long_title}
-                            short_title={short_title}
-                            url={
-                                "https://uscode.house.gov/download/releasepoints/us/pl/116/78/usc-rp@116-78.htm"
-                            }
-                        />
-                    ),
-                )}
+    const executeSearch = () => {
+        if (!query.trim()) return;
+        getUSCodeSearch(query).then((results) => {
+            setSearchResults(results);
+        });
+    };
+
+    const renderSearchResults = () => {
+        if (!searchResults || searchResults.length === 0) return null;
+        return searchResults.map((result, index) => (
+            <SectionCard
+                key={`search-result-${index}`}
+                className="search-result"
+            >
+                <h3>{result.title}</h3>
+                <h4>{result.sectionHeader}</h4>
             </SectionCard>
-        </Section>
+        ));
+    };
+
+    return (
+        <>
+            <Section
+                className="page"
+                title="United States Code"
+                subtitle="The Foundation of U.S. Law"
+            >
+                <Section
+                    className="full"
+                    title="Release Points"
+                    subtitle="Different versions of the USCode, typically aligned around the passage of major legislation"
+                    icon="pin"
+                    collapsible={true}
+                >
+                    {lodash.map(
+                        releases,
+                        (
+                            {
+                                usc_release_id,
+                                effective_date,
+                                long_title,
+                                short_title,
+                                url,
+                            },
+                            ind,
+                        ) => (
+                            <USCRevisionBox
+                                key={`usc-rev-box-${ind}`}
+                                usc_release_id={usc_release_id}
+                                effective_date={effective_date}
+                                long_title={long_title}
+                                short_title={short_title}
+                                url={
+                                    "https://uscode.house.gov/download/releasepoints/us/pl/116/78/usc-rp@116-78.htm"
+                                }
+                            />
+                        ),
+                    )}
+                </Section>
+                <Section
+                    className="full"
+                    title="Intelligent Search"
+                    subtitle="Search the USCode for sections pertaining to a specific topic using natural language"
+                    icon="search-text"
+                    collapsible={true}
+                >
+                    <InputGroup
+                        placeholder="Enter search text..."
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        rightElement={
+                            <Button icon="search" onClick={executeSearch} />
+                        }
+                    />
+                    <div className="search-results">
+                        {renderSearchResults()}
+                    </div>
+                </Section>
+            </Section>
+        </>
     );
 }
 

--- a/frontend/src/pages/uscode-revision-list/index.jsx
+++ b/frontend/src/pages/uscode-revision-list/index.jsx
@@ -1,15 +1,24 @@
 import React, { useEffect, useState } from "react";
 import lodash from "lodash";
-import { Section, SectionCard, InputGroup, Button } from "@blueprintjs/core";
+import {
+    Section,
+    SectionCard,
+    InputGroup,
+    Button,
+    Collapse,
+    Icon,
+} from "@blueprintjs/core";
 
-import { USCRevisionBox } from "components";
+import { USCRevisionBox, USCView } from "components";
 import { getUSCRevisions, getUSCodeSearch } from "common/api";
 
+import { getUSCSectionContent } from "common/api";
+import { md5 } from "common/other";
 function USCodeRevisionList() {
     const [releases, setReleases] = useState([]);
     const [query, setQuery] = useState("");
     const [searchResults, setSearchResults] = useState([]);
-
+    const [expandedResults, setExpandedResults] = useState({});
     useEffect(() => {
         getUSCRevisions().then(setReleases);
     }, []);
@@ -20,18 +29,86 @@ function USCodeRevisionList() {
             setSearchResults(results);
         });
     };
+    const toggleExpand = (index) => {
+        setExpandedResults((prev) => ({
+            ...prev,
+            [index]: !prev[index],
+        }));
+    };
 
     const renderSearchResults = () => {
         if (!searchResults || searchResults.length === 0) return null;
-        return searchResults.map((result, index) => (
-            <SectionCard
-                key={`search-result-${index}`}
-                className="search-result"
-            >
-                <h3>Ch. {result.usc_link.split("/")[0]} - {result.title}</h3>
-                <h4>S. {result.usc_link.split("/")[1]} - {result.section_display}</h4>
-            </SectionCard>
-        ));
+        return searchResults.map((result, index) => {
+            const isExpanded = !!expandedResults[index];
+
+            return (
+                <SectionCard
+                    key={`search-result-${index}`}
+                    className="search-result"
+                >
+                    <div
+                        className="result-header"
+                        onClick={() => toggleExpand(index)}
+                        style={{
+                            cursor: "pointer",
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                        }}
+                    >
+                        <div>
+                            <strong>
+                                Ch. {result.usc_link.split("/")[0]} -{" "}
+                                {result.title} | S.{" "}
+                                {result.usc_link.split("/")[1]} -{" "}
+                                {result.section_display}
+                            </strong>
+                        </div>
+                        <Icon
+                            icon={isExpanded ? "chevron-up" : "chevron-down"}
+                        />
+                    </div>
+
+                    <Collapse isOpen={isExpanded}>
+                        <div
+                            className="result-content"
+                            style={{ marginTop: "10px" }}
+                        >
+                            <USCView
+                                release={"latest"}
+                                section={result.usc_link.split("/")[1]}
+                                title={result.usc_link.split("/")[0]}
+                                
+                            />
+                        </div>
+                    </Collapse>
+
+                    {!isExpanded && (
+                        <div
+                            className="text-preview"
+                            style={{
+                                marginTop: "5px",
+                                color: "#666",
+                                maxHeight: "3em", // Set a maximum height (approximately 2-3 lines)
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                display: "-webkit-box",
+                                WebkitLineClamp: 2, // Number of lines to show
+                                WebkitBoxOrient: "vertical"
+                            }}
+                        >
+                          {console.log("hidden")}
+                           <USCView
+                                release={"latest"}
+                                section={result.usc_link.split("/")[1]}
+                                title={result.usc_link.split("/")[0]}
+                                lines={3}
+                            />
+                        </div>
+                    )}
+                </SectionCard>
+            );
+        });
     };
 
     return (

--- a/frontend/src/pages/uscode-revision-list/index.jsx
+++ b/frontend/src/pages/uscode-revision-list/index.jsx
@@ -78,7 +78,6 @@ function USCodeRevisionList() {
                                 release={"latest"}
                                 section={result.usc_link.split("/")[1]}
                                 title={result.usc_link.split("/")[0]}
-                                
                             />
                         </div>
                     </Collapse>
@@ -94,11 +93,11 @@ function USCodeRevisionList() {
                                 textOverflow: "ellipsis",
                                 display: "-webkit-box",
                                 WebkitLineClamp: 2, // Number of lines to show
-                                WebkitBoxOrient: "vertical"
+                                WebkitBoxOrient: "vertical",
                             }}
                         >
-                          {console.log("hidden")}
-                           <USCView
+                            {console.log("hidden")}
+                            <USCView
                                 release={"latest"}
                                 section={result.usc_link.split("/")[1]}
                                 title={result.usc_link.split("/")[0]}
@@ -161,6 +160,11 @@ function USCodeRevisionList() {
                         placeholder="Enter search text..."
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                executeSearch();
+                            }
+                        }}
                         rightElement={
                             <Button icon="search" onClick={executeSearch} />
                         }


### PR DESCRIPTION
Created a vector db to hold sections of the USCode, and we can now search them via natural language.
Reusing the USCView component to make this dead simple, eventually maybe the search results return the section data themselves, but this way I suppose caching might be more effective since it makes the same API call as the normal viewer.
![image](https://github.com/user-attachments/assets/a8c5e230-ab40-4cd8-8fcc-183d52ec6119)
